### PR TITLE
Adds optional serial prints, pin definitions for Arduino Nano CNC shield, adjustable max servo angle and start/end position

### DIFF
--- a/SelectorFirmwareMk4/SelectorFirmwareMk4.ino
+++ b/SelectorFirmwareMk4/SelectorFirmwareMk4.ino
@@ -134,6 +134,7 @@ SX1509 io;                        // Create an SX1509 object to be used througho
 
 #if 0
 // defines pins numbers - 3D Chameleon Board
+
 #define extEnable 0
 #define extStep 1
 #define extDir 2
@@ -145,8 +146,12 @@ SX1509 io;                        // Create an SX1509 object to be used througho
 #define trigger A3
 #define s_limit A4
 #define filament A5
+#define filamentCutterPin 11
+
+
 #elif defined(ARDUINO_AVR_UNO)
 // Arduino Uno -- see https://www.instructables.com/Fix-Cloned-Arduino-NANO-CNC-Shield/#:~:text=Lines%2047%2C48%20%26%2049-,need%20replacing%20with,-%3A
+
 #define extEnable 8
 #define extStep 2
 #define extDir 5
@@ -158,8 +163,12 @@ SX1509 io;                        // Create an SX1509 object to be used througho
 #define trigger A3
 #define s_limit A4
 #define filament A5
+#define filamentCutterPin 11
+
+
 #elif defined(ARDUINO_AVR_NANO)
 // Nano CNC Shield, HW-702 v0.0.0 - ensure follow guide above to correct microstepping pcb traces!
+
 #define extEnable 8
 #define extStep 5
 #define extDir 2
@@ -171,6 +180,8 @@ SX1509 io;                        // Create an SX1509 object to be used througho
 #define trigger A3
 #define s_limit A4
 #define filament A5
+#define filamentCutterPin A7
+
 #endif
 
 
@@ -781,7 +792,7 @@ void cutFilament() {
 // enable the servo
 void connectGillotine()
 {
-  filamentCutter.attach(11);
+  filamentCutter.attach(filamentCutterPin);
 }
 
 // disable the servo - so it doesn't chatter when not in use

--- a/SelectorFirmwareMk4/SelectorFirmwareMk4.ino
+++ b/SelectorFirmwareMk4/SelectorFirmwareMk4.ino
@@ -41,7 +41,7 @@ Single Button Press Commands (count pulses of selector)
 
 #define SCREEN_WIDTH 128 // OLED display width, in pixels
 #define SCREEN_HEIGHT 64 // OLED display height, in pixels
-
+#define USE_SERIAL 0 // 0 = no serial output, 1 = serial output
 /**
  * Made with Marlin Bitmap Converter
  * https://marlinfw.org/tools/u8glib/converter.html
@@ -132,7 +132,7 @@ const byte SX1509_ADDRESS = 0x3E; // SX1509 I2C address
 #define SX1509_OUTPUT 4
 SX1509 io;                        // Create an SX1509 object to be used throughout
 
-
+#if 0
 // defines pins numbers - 3D Chameleon Board
 #define extEnable 0
 #define extStep 1
@@ -145,6 +145,34 @@ SX1509 io;                        // Create an SX1509 object to be used througho
 #define trigger A3
 #define s_limit A4
 #define filament A5
+#elif defined(ARDUINO_AVR_UNO)
+// Arduino Uno -- see https://www.instructables.com/Fix-Cloned-Arduino-NANO-CNC-Shield/#:~:text=Lines%2047%2C48%20%26%2049-,need%20replacing%20with,-%3A
+#define extEnable 8
+#define extStep 2
+#define extDir 5
+
+#define selEnable 8
+#define selStep 3
+#define selDir 6
+
+#define trigger A3
+#define s_limit A4
+#define filament A5
+#elif defined(ARDUINO_AVR_NANO)
+// Nano CNC Shield, HW-702 v0.0.0 - ensure follow guide above to correct microstepping pcb traces!
+#define extEnable 8
+#define extStep 5
+#define extDir 2
+
+#define selEnable 8
+#define selStep 6
+#define selDir 3
+
+#define trigger A3
+#define s_limit A4
+#define filament A5
+#endif
+
 
 const int counterclockwise = HIGH;
 const int clockwise = !counterclockwise;
@@ -196,6 +224,11 @@ long randomNumber = 0;
 
 void setup()
 {
+  if (USE_SERIAL) {
+    Serial.begin(115200);
+    delay(500);
+    Serial.println("Serial Enabled");
+  }
 
   Wire.begin(); //start i2C  
 	Wire.setClock(400000L); //set clock
@@ -209,6 +242,10 @@ void setup()
     io.pinMode(SX1509_FILAMENT_3, INPUT_PULLUP);
     io.pinMode(SX1509_OUTPUT, OUTPUT);
     ioEnabled = true;
+  }
+  if (USE_SERIAL) {
+    Serial.print("IO Expander: ");
+    Serial.println(ioEnabled);
   }
 
   // enable OLED display
@@ -273,6 +310,9 @@ void loop()
   // process button press
   if (digitalRead(trigger) == 0)
   {
+    if (USE_SERIAL) {
+      Serial.println("Button Depressed");
+    }
     idleCount = 0;
     logoActive = false;
     unsigned long nextPulse;
@@ -289,6 +329,9 @@ void loop()
         if(pulseCount>1) vibrateMotor();
       }
       delay(400);  // each pulse is 400+ milliseconds apart 
+    }
+    if (USE_SERIAL) {
+      Serial.println("Button Released");
     }
     processCommand(pulseCount); // ok... execute whatever command was caught (by pulse count)
     pulseCount = 0;
@@ -479,7 +522,11 @@ void processCommand(long commandCount)
 // just the routine to update the OLED
 void displayText(int offset, String str)
 {
-
+  if (USE_SERIAL) {
+    Serial.print(offset);
+    Serial.print(": ");
+    Serial.println(str);
+  } 
   //if(displayEnabled){
     oled.clear();
     oled.println("");

--- a/SelectorFirmwareMk4/SelectorFirmwareMk4.ino
+++ b/SelectorFirmwareMk4/SelectorFirmwareMk4.ino
@@ -42,6 +42,7 @@ Single Button Press Commands (count pulses of selector)
 #define SCREEN_WIDTH 128 // OLED display width, in pixels
 #define SCREEN_HEIGHT 64 // OLED display height, in pixels
 #define USE_SERIAL 0 // 0 = no serial output, 1 = serial output
+#define SERVO_MAX_ANGLE 180
 /**
  * Made with Marlin Bitmap Converter
  * https://marlinfw.org/tools/u8glib/converter.html
@@ -150,7 +151,7 @@ SX1509 io;                        // Create an SX1509 object to be used througho
 
 
 #elif defined(ARDUINO_AVR_UNO)
-// Arduino Uno -- see https://www.instructables.com/Fix-Cloned-Arduino-NANO-CNC-Shield/#:~:text=Lines%2047%2C48%20%26%2049-,need%20replacing%20with,-%3A
+// Arduino Uno -- CNC Shield V3?
 
 #define extEnable 8
 #define extStep 2
@@ -167,7 +168,8 @@ SX1509 io;                        // Create an SX1509 object to be used througho
 
 
 #elif defined(ARDUINO_AVR_NANO)
-// Nano CNC Shield, HW-702 v0.0.0 - ensure follow guide above to correct microstepping pcb traces!
+// Nano CNC Shield (aka CNC Shield V4), HW-702 v0.0.0 - ensure follow guide below to correct microstepping pcb traces if needed!
+// see https://www.instructables.com/Fix-Cloned-Arduino-NANO-CNC-Shield/#:~:text=Lines%2047%2C48%20%26%2049-,need%20replacing%20with,-%3A
 
 #define extEnable 8
 #define extStep 5
@@ -177,12 +179,17 @@ SX1509 io;                        // Create an SX1509 object to be used througho
 #define selStep 6
 #define selDir 3
 
-#define trigger A3
-#define s_limit A4
-#define filament A5
-#define filamentCutterPin A7
+#define trigger A3           // pcb labelled Coolant ENable
+#define s_limit A2           // pcb labelled Resume
+#define filament A1          // pcb labelled Hold
+#define filamentCutterPin 11 // pcb labelled Z+/- endstop
 
 #endif
+
+
+#define SERVO_START_ANGLE_AS_180_SERVO 135 * (180 / SERVO_MAX_ANGLE)
+#define SERVO_END_ANGLE_AS_180_SERVO 180 * (180 / SERVO_MAX_ANGLE)
+
 
 
 const int counterclockwise = HIGH;
@@ -804,7 +811,7 @@ void disconnectGillotine()
 // cycle servo from 135 and 180
 void openGillotine()
 {
-    for (int pos = 135; pos <= 180; pos += 1) { // goes from 0 degrees to 180 degrees
+    for (int pos = SERVO_START_ANGLE_AS_180_SERVO; pos <= SERVO_END_ANGLE_AS_180_SERVO; pos += 1) { // goes from 0 degrees to 180 degrees
     // in steps of 1 degree
     filamentCutter.write(pos);              // tell servo to go to position in variable 'pos'
     delayMicroseconds(25000);                       // waits 15ms for the servo to reach the position
@@ -816,7 +823,7 @@ void openGillotine()
 // reverse cycle servo from 180 back to 135
 void closeGillotine()
 {
-  for (int pos = 180; pos >= 135; pos -= 1) { // goes from 180 degrees to 0 degrees
+  for (int pos = SERVO_END_ANGLE_AS_180_SERVO; pos >= SERVO_START_ANGLE_AS_180_SERVO; pos -= 1) { // goes from 180 degrees to 0 degrees
     filamentCutter.write(pos);              // tell servo to go to position in variable 'pos'
     delayMicroseconds(25000);                       // waits 15ms for the servo to reach the position
   }
@@ -844,4 +851,3 @@ void vibrateMotor()
   rotateSelector(clockwise, 2 * 16);
   rotateSelector(!clockwise, 2 * 16);
 }
-


### PR DESCRIPTION
This adds the optional Serial prints for any users without a display (during testing or generally). 
It's toggled with the #define USE_SERIAL 1

Additionally the pins are now selected based on which microcontroller is detected. It assumes people have the arduino uno or nano processors, the original pin definitions are now protected behind an #if 0 check. Maybe it should be #if 1 for compatibility with the existing custom PCBs.

Lastly, the Servo for the auto-clippy has the pin number #define set at the top of the file (per board like other pins), along with a #define for the range of the servo (SERVO_MAX_ANGLE), and then that is applied to the 135degree / 180degree cutting methods (or whatever angles the user wishes).